### PR TITLE
line_idをdbに書き込み&dbから削除

### DIFF
--- a/projects/rails-backend/Gemfile
+++ b/projects/rails-backend/Gemfile
@@ -18,7 +18,7 @@ gem 'puma', '~> 5.0'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
-
+gem 'line-bot-api'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 

--- a/projects/rails-backend/Gemfile.lock
+++ b/projects/rails-backend/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    line-bot-api (1.20.0)
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -151,6 +152,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
+  line-bot-api
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/projects/rails-backend/app/controllers/webhook_controller.rb
+++ b/projects/rails-backend/app/controllers/webhook_controller.rb
@@ -1,5 +1,6 @@
 class WebhookController < ActionController::API
  require 'line/bot' 
+  private
   def client
     @client ||= Line::Bot::Client.new { |config|
       config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
@@ -7,6 +8,7 @@ class WebhookController < ActionController::API
     }
   end
 
+  public
   def callback
 
     body = request.body.read

--- a/projects/rails-backend/app/controllers/webhook_controller.rb
+++ b/projects/rails-backend/app/controllers/webhook_controller.rb
@@ -1,0 +1,36 @@
+class WebhookController < ActionController::API
+ require 'line/bot' 
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+
+  def callback
+
+    body = request.body.read
+
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+    unless client.validate_signature(body, signature)
+      head :bad_request
+    end
+
+    events = client.parse_events_from(body)
+
+    events.each { |event|
+
+      case event
+      when Line::Bot::Event::Follow
+        user_id = event['source']['userId']
+        user = User.create(line_id: user_id)
+
+      when Line::Bot::Event::Unfollow
+        user_id = event['source']['userId']
+        user = User.destroy_by(line_id: user_id)
+      end
+    }
+
+    head :ok
+  end
+end

--- a/projects/rails-backend/config/environments/development.rb
+++ b/projects/rails-backend/config/environments/development.rb
@@ -63,4 +63,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.hosts << ".ngrok.io"
 end

--- a/projects/rails-backend/config/routes.rb
+++ b/projects/rails-backend/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get "hello_world", to: 'application#hello_world'
+
+  post "callback", to: 'webhook#callback'
+
 end

--- a/projects/rails-backend/db/schema.rb
+++ b/projects/rails-backend/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_08_04_100926) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "line_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end


### PR DESCRIPTION
**実装の背景・目的**  
line_idをDBに保存して、送信先を管理するため

**やったこと**  
line-bot-apiのインストール
ルートの追加
webhook_controllerの作成
【処理】
・LINEの友達が追加されるとその人のLINE IDがDBに保存されていく。
・ブロックされるとブロックした人のLINE  IDがDBから消される。

**補足 **
ngrokを用いて試すためにconfigファイルにngrokからのアクセスを許可させています